### PR TITLE
Claim supporting `textDocument/semanticTokens` capability

### DIFF
--- a/plugin/core/sessions.py
+++ b/plugin/core/sessions.py
@@ -257,6 +257,56 @@ def get_initialize_params(variables: Dict[str, str], workspace_folders: List[Wor
             },
             "codeLens": {
                 "dynamicRegistration": True
+            },
+            "semanticTokens": {
+                "dynamicRegistration": True,
+                "tokenTypes": [
+                    "namespace",
+                    "type",
+                    "class",
+                    "enum",
+                    "interface",
+                    "struct",
+                    "typeParameter",
+                    "parameter",
+                    "variable",
+                    "property",
+                    "enumMember",
+                    "event",
+                    "function",
+                    "method",
+                    "macro",
+                    "keyword",
+                    "modifier",
+                    "comment",
+                    "string",
+                    "number",
+                    "regexp",
+                    "operator"
+                ],
+                "tokenModifiers": [
+                    "declaration",
+                    "definition",
+                    "readonly",
+                    "static",
+                    "deprecated",
+                    "abstract",
+                    "async",
+                    "modification",
+                    "documentation",
+                    "defaultLibrary"
+                ],
+                "formats": [
+                    "relative"
+                ],
+                "requests": {
+                    "range": True,
+                    "full": {
+                        "delta": True
+                    }
+                },
+                "multilineTokenSupport": False,
+                "overlappingTokenSupport": False
             }
         },
         "workspace": {


### PR DESCRIPTION
@litezzzout After this, Pylance does semantic highlighting. Copied from what VSCode sends to Pylance.